### PR TITLE
JAVASE-5 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
@@ -194,6 +194,7 @@ public class JavaRulingTest {
     String projectName = "jboss-ejb3-tutorial";
     prepareProject(projectName, projectName);
     SonarScanner build = SonarScanner.create(FileLocation.of("../sources/jboss-ejb3-tutorial").getFile())
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProperty("sonar.java.fileByFile", "true")
       .setProjectKey(projectName)
       .setProjectName(projectName)
@@ -224,6 +225,7 @@ public class JavaRulingTest {
     File pomFile = FileLocation.of(pomLocation).getFile().getCanonicalFile();
     prepareProject(projectKey, projectName);
     MavenBuild mavenBuild = MavenBuild.create().setPom(pomFile).setCleanPackageSonarGoals().addArgument("-DskipTests");
+    mavenBuild.setProperty("sonar.scanner.skipJreProvisioning", "true");
     mavenBuild.setProperty("sonar.projectKey", projectKey);
     return mavenBuild;
   }


### PR DESCRIPTION
[JAVASE-5](https://sonarsource.atlassian.net/browse/JAVASE-5)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.

[JAVASE-5]: https://sonarsource.atlassian.net/browse/JAVASE-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ