### PR TITLE
JAVASE-178 Use shared bump-version workflow and bump up the version with maven

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -40,6 +40,10 @@ on:
         description: "Integrate into SQS"
         type: boolean
         default: true
+      bump-version:
+        description: "Create PR to bump the next iteration version"
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -55,6 +59,7 @@ jobs:
       project-name: "SonarJava Symbolic Execution"
       plugin-name: "java-symbolic-execution"
       jira-project-key: "JAVASE"
+      runner-environment: "github-ubuntu-latest-s"
       rule-props-changed: ${{ github.event.inputs.rule-props-changed }}
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}
@@ -69,5 +74,6 @@ jobs:
       verbose: ${{ github.event.inputs.verbose == 'true' }}
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
-      bump-version: true
+      bump-version: ${{ github.event.inputs.bump-version == 'true' }}
       bump-version-normalize: true
+      bump-version-tool: maven

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@9b321c6d450221dde053574d55e721f52ddfe261
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@tt/bump-version-command
     permissions:
       statuses: read
       id-token: write
@@ -76,3 +76,4 @@ jobs:
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
       bump-version: ${{ github.event.inputs.bump-version == 'true' }}
       bump-version-normalize: true
+      bump-version-tool: maven

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@tt/bump-version-command
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@9b321c6d450221dde053574d55e721f52ddfe261
     permissions:
       statuses: read
       id-token: write
@@ -76,4 +76,3 @@ jobs:
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
       bump-version: ${{ github.event.inputs.bump-version == 'true' }}
       bump-version-normalize: true
-      bump-version-tool: maven

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@tt/bump-version-command
     permissions:
       statuses: read
       id-token: write

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@tt/bump-version-command
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
     permissions:
       statuses: read
       id-token: write


### PR DESCRIPTION
* Make it possible to disable version bump - this is useful during testing to reduce noise.
* Use maven, because that's the standard for JVM Squad's maven projects (`pom.xml` in test will remain unchanged).
* Also fix `runner-environment: "github-ubuntu-latest-s"`