### PR TITLE
JAVASE-183 Add issue-categories in automated release

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -75,5 +75,6 @@ jobs:
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
       bump-version: ${{ github.event.inputs.bump-version == 'true' }}
+      issue-categories: "Feature,False Positive,False Negative,Bug,Security,Maintenance"
       bump-version-normalize: true
       bump-version-tool: maven


### PR DESCRIPTION
They were missing and the default does not include `maintenance`.