### PR TITLE
JAVASE-193 Do not run nightly builds on weekends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "30 1 * * 1-5" # Run Mon-Fri at 1:30 AM UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -1,7 +1,7 @@
 name: unified-dogfooding.yml
 on:
   schedule:
-    - cron: '0 3 * * *' # Run the workflow every day at 03:00 UTC
+    - cron: '0 3 * * 1-5' # Run Mon-Fri at 03:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Restrict scheduled workflow runs to weekdays (Mon-Fri) to avoid unnecessary weekend builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)