### PR TITLE
GHA-355 Add statuses: write permission for release-lock feature

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -50,7 +50,7 @@ jobs:
     name: Release
     uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
     permissions:
-      statuses: read
+      statuses: write
       id-token: write
       contents: write
       actions: write


### PR DESCRIPTION
## Summary

- Add `statuses: write` to the `permissions` block of the job calling `automated-release.yml`

## Why

The `set-release-lock` and `clear-release-lock` jobs in `SonarSource/release-github-actions/.github/workflows/automated-release.yml` write commit statuses to block non-bump PRs from merging during a release. When `bump-version: true` is passed, those jobs need the caller to grant `statuses: write`.

Without this, GitHub rejects the workflow call at parse time with:
> The nested job 'set-release-lock' is requesting 'statuses: write', but is only allowed 'statuses: read'.

**Note:** A parallel fix in `release-github-actions` ([PR #176](https://github.com/SonarSource/release-github-actions/pull/176)) switches those jobs to use a vault token instead, which may make this caller-side change unnecessary. This PR is a belt-and-suspenders fix for the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
